### PR TITLE
Try-except for better exceptions

### DIFF
--- a/datastream/dataset.py
+++ b/datastream/dataset.py
@@ -4,6 +4,8 @@ from typing import (
     Tuple, Callable, Any, Union, List, TypeVar, Generic, Dict, Optional
 )
 from pathlib import Path
+from functools import lru_cache
+import textwrap
 import inspect
 import numpy as np
 import pandas as pd
@@ -132,9 +134,7 @@ class Dataset(BaseModel, torch.utils.data.Dataset, Generic[T]):
             try:
                 return function(item)
             except Exception as e:
-                item_text = str(item)
-                if len(item_text) > 79:
-                    item_text = item_text[:79] + ' ...'
+                item_text = textwrap.shorten(str(item), width=79)
 
                 raise Exception('\n'.join([
                     repr(e),
@@ -434,10 +434,11 @@ class Dataset(BaseModel, torch.utils.data.Dataset, Generic[T]):
             ))
         )
 
-    def cache(self, key_column):
-        '''Cache dataset in-memory based on key column.'''
-        from functools import lru_cache
-
+    def cache(
+        self,
+        key_column: str,
+    ):
+        '''Cache intermediate step in-memory based on key column.'''
         key_mapping = dict(zip(
             self.dataframe[key_column],
             range(len(self)),

--- a/datastream/dataset.py
+++ b/datastream/dataset.py
@@ -434,6 +434,27 @@ class Dataset(BaseModel, torch.utils.data.Dataset, Generic[T]):
             ))
         )
 
+    def cache(self, key_column):
+        '''Cache dataset in-memory based on key column.'''
+        from functools import lru_cache
+
+        key_mapping = dict(zip(
+            self.dataframe[key_column],
+            range(len(self)),
+        ))
+
+        @lru_cache(maxsize=None)
+        def only_key(key):
+            return self.get_item(self.dataframe, key_mapping[key])
+
+        return Dataset(
+            dataframe=self.dataframe,
+            length=self.length,
+            get_item=lambda dataframe, index: only_key(
+                dataframe.iloc[index][key_column]
+            ),
+        )
+
 
 def test_equal():
     dataset1 = Dataset.from_subscriptable([4, 7, 12])

--- a/datastream/dataset.py
+++ b/datastream/dataset.py
@@ -141,7 +141,7 @@ class Dataset(BaseModel, torch.utils.data.Dataset, Generic[T]):
                     'Above exception occured in the pipeline for',
                     'item:',
                     item_text,
-                    f'file: {inspect.getfile(function)}',
+                    f'module: {inspect.getmodule(function)}',
                     'source:',
                     inspect.getsource(function),
                 ])) from e

--- a/datastream/dataset.py
+++ b/datastream/dataset.py
@@ -138,13 +138,14 @@ class Dataset(BaseModel, torch.utils.data.Dataset, Generic[T]):
 
                 raise Exception('\n'.join([
                     repr(e),
-                    'Above exception occured in the pipeline for',
-                    'item:',
-                    item_text,
+                    '',
+                    'Above exception originated from',
                     f'module: {inspect.getmodule(function)}',
-                    'source:',
+                    'from mapped function:',
                     inspect.getsource(function),
-                ])) from e
+                    'for item:',
+                    item_text,
+                ])).with_traceback(e.__traceback__)
 
         return Dataset(
             dataframe=self.dataframe,

--- a/datastream/datastream.py
+++ b/datastream/datastream.py
@@ -12,6 +12,7 @@ from typing import (
 )
 import numpy as np
 import torch
+from pathlib import Path
 
 from datastream import Dataset
 from datastream.samplers import (
@@ -253,7 +254,10 @@ class Datastream(BaseModel, Generic[T]):
             MultiSampler.from_number(n, self.dataset),
         )
 
-    def cache(self, key_column):
+    def cache(
+        self,
+        key_column: str,
+    ):
         '''Cache dataset in-memory. See :func:`Dataset.cache` for details.'''
         return Datastream(
             self.dataset.cache(key_column),

--- a/datastream/datastream.py
+++ b/datastream/datastream.py
@@ -253,6 +253,13 @@ class Datastream(BaseModel, Generic[T]):
             MultiSampler.from_number(n, self.dataset),
         )
 
+    def cache(self, key_column):
+        '''Cache dataset in-memory. See :func:`Dataset.cache` for details.'''
+        return Datastream(
+            self.dataset.cache(key_column),
+            self.sampler,
+        )
+
 
 def test_datastream_merge():
 

--- a/datastream/tools/star.py
+++ b/datastream/tools/star.py
@@ -1,4 +1,9 @@
+from functools import wraps
+
 
 def star(fn):
     '''Wrap function to expand input to arguments'''
-    return lambda args: fn(*args)
+    @wraps(fn)
+    def wrapper(args):
+        return fn(*args)
+    return wrapper


### PR DESCRIPTION
Try-except is fast as long as "except" does not happen so this should be fine for us. Really helpful messages but could maybe get too verbose to show "item".

Example:
```
  File "/home/richard/Documents/pytorch-datastream/datastream/dataset.py", line 135, in composed_fn
    raise Exception('\n'.join([
Exception: TypeError("<lambda>() missing 1 required positional argument: 'match_id'")
Above exception occured in the pipeline for
item:
('red', '4676460676')
file: /home/richard/Documents/league/venv/.guild/runs/729ed590e2054f13bfced64d4a4fb02f/.guild/sourcecode/league/problem/evaluate_datasets.py
source:
        .map(lambda side, match_id: (
            side,
            Match.from_disk(match_id),
        ))

```