### PR TITLE
Cache dataset in-memory

### DIFF
--- a/datastream/dataset.py
+++ b/datastream/dataset.py
@@ -434,6 +434,27 @@ class Dataset(BaseModel, torch.utils.data.Dataset, Generic[T]):
             ))
         )
 
+    def cache(self, key_column):
+        '''Cache dataset in-memory based on key column.'''
+        from functools import lru_cache
+
+        key_mapping = dict(zip(
+            self.dataframe[key_column],
+            range(len(self)),
+        ))
+
+        @lru_cache(maxsize=None)
+        def only_key(key):
+            return self.get_item(self.dataframe, key_mapping[key])
+
+        return Dataset(
+            dataframe=self.dataframe,
+            length=self.length,
+            get_item=lambda dataframe, index: only_key(
+                dataframe.iloc[index][key_column]
+            ),
+        )
+
 
 def test_equal():
     dataset1 = Dataset.from_subscriptable([4, 7, 12])

--- a/datastream/datastream.py
+++ b/datastream/datastream.py
@@ -253,6 +253,13 @@ class Datastream(BaseModel, Generic[T]):
             MultiSampler.from_number(n, self.dataset),
         )
 
+    def cache(self, key_column):
+        '''Cache dataset in-memory. See :func:`Dataset.cache` for details.'''
+        return Datastream(
+            self.dataset.cache(key_column),
+            self.sampler,
+        )
+
 
 def test_datastream_merge():
 


### PR DESCRIPTION
Do we want something like this? It's useful in my league project but I can also cache outside pytorch-datastream relatively easily like this (after a bit of refactoring):
```
.starmap(lru_cache(maxsize=None)(problem.Example.from_match_id))
```

This is related to caching/checkpointing to disk (which also very related to our "prepare" operations).

Note: I have not tested this well enough with multiprocessing. I'm not doing mp since I can fit my dataset in memory.