### PR TITLE
Conform group_split to the name change Dataset.functions -> get_item

### DIFF
--- a/datastream/dataset.py
+++ b/datastream/dataset.py
@@ -298,7 +298,7 @@ class Dataset(BaseModel, torch.utils.data.Dataset, Generic[T]):
             split_name: Dataset(
                 dataframe=dataframe,
                 length=len(dataframe),
-                functions=self.functions,
+                get_item=self.get_item,
             )
             for split_name, dataframe in split_dataframes(
                 self.dataframe,


### PR DESCRIPTION
I think this change didn't exist in my repo when I developed `group_split` so that's why it passed the tests. The commit in master fails the tests, but with this it should work.