### PR TITLE
fix: set correct version for pbr under python 3.6

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,10 @@ jobs:
       run: |
         pip install strip-hints==0.1.9
         ./patch-python3.6.sh
+        git add --all
+        git commit --message "Python 3.6 patch"
+        latest_tag=$(git describe --abbrev=0 --tags)
+        git tag --force ${latest_tag}
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
fake move the tag forward so that pbr uses the pre-patch version tag