### PR TITLE
Simplify split

### DIFF
--- a/datastream/dataset.py
+++ b/datastream/dataset.py
@@ -804,8 +804,7 @@ def test_update_stratified_split():
         Dataset.from_dataframe(pd.DataFrame(dict(
             index=np.arange(100),
             number=np.random.randn(100),
-            stratify1=np.random.randint(0, 10, 100),
-            stratify2=np.random.randint(0, 10, 100),
+            stratify=np.random.randint(0, 10, 100),
         )))
         .map(tuple)
     )
@@ -819,7 +818,7 @@ def test_update_stratified_split():
             key_column='index',
             proportions=dict(train=0.8, test=0.2),
             filepath=filepath,
-            stratify_column='stratify1',
+            stratify_column='stratify',
         )
     )
 
@@ -829,7 +828,7 @@ def test_update_stratified_split():
             key_column='index',
             proportions=dict(train=0.8, test=0.2),
             filepath=filepath,
-            stratify_column='stratify2',
+            stratify_column='stratify',
         )
     )
 
@@ -840,8 +839,8 @@ def test_update_stratified_split():
     )
 
     assert (
-        splits1['compare'].dataframe['index']
-        .isin(splits2['compare'].dataframe['index'])
+        splits1['test'].dataframe['index']
+        .isin(splits2['test'].dataframe['index'])
         .all()
     )
 

--- a/datastream/dataset.py
+++ b/datastream/dataset.py
@@ -800,48 +800,51 @@ def test_split_filepath():
 
 def test_update_stratified_split():
 
-    dataset = (
-        Dataset.from_dataframe(pd.DataFrame(dict(
-            index=np.arange(100),
-            number=np.random.randn(100),
-            stratify=np.random.randint(0, 10, 100),
-        )))
-        .map(tuple)
-    )
+    for _ in range(5):
 
-    filepath = Path('tmp_test_split.json')
-
-    splits1 = (
-        dataset
-        .subset(lambda df: df['index'] < 50)
-        .split(
-            key_column='index',
-            proportions=dict(train=0.8, test=0.2),
-            filepath=filepath,
-            stratify_column='stratify',
+        dataset = (
+            Dataset.from_dataframe(pd.DataFrame(dict(
+                index=np.arange(100),
+                number=np.random.randn(100),
+                stratify1=np.random.randint(0, 10, 100),
+                stratify2=np.random.randint(0, 10, 100),
+            )))
+            .map(tuple)
         )
-    )
 
-    splits2 = (
-        dataset
-        .split(
-            key_column='index',
-            proportions=dict(train=0.8, test=0.2),
-            filepath=filepath,
-            stratify_column='stratify',
+        filepath = Path('tmp_test_split.json')
+
+        splits1 = (
+            dataset
+            .subset(lambda df: df['index'] < 50)
+            .split(
+                key_column='index',
+                proportions=dict(train=0.8, test=0.2),
+                filepath=filepath,
+                stratify_column='stratify1',
+            )
         )
-    )
 
-    assert (
-        splits1['train'].dataframe['index']
-        .isin(splits2['train'].dataframe['index'])
-        .all()
-    )
+        splits2 = (
+            dataset
+            .split(
+                key_column='index',
+                proportions=dict(train=0.8, test=0.2),
+                filepath=filepath,
+                stratify_column='stratify2',
+            )
+        )
 
-    assert (
-        splits1['test'].dataframe['index']
-        .isin(splits2['test'].dataframe['index'])
-        .all()
-    )
+        assert (
+            splits1['train'].dataframe['index']
+            .isin(splits2['train'].dataframe['index'])
+            .all()
+        )
 
-    filepath.unlink()
+        assert (
+            splits1['test'].dataframe['index']
+            .isin(splits2['test'].dataframe['index'])
+            .all()
+        )
+
+        filepath.unlink()

--- a/datastream/tools/__init__.py
+++ b/datastream/tools/__init__.py
@@ -3,3 +3,5 @@ from datastream.tools.starcompose import starcompose
 from datastream.tools.repeat_map_chain import repeat_map_chain
 from datastream.tools.numpy_seed import numpy_seed
 from datastream.tools.split_dataframes import split_dataframes
+from datastream.tools.unstratified_split import unstratified_split
+from datastream.tools.stratified_split import stratified_split

--- a/datastream/tools/__init__.py
+++ b/datastream/tools/__init__.py
@@ -2,6 +2,4 @@ from datastream.tools.star import star
 from datastream.tools.starcompose import starcompose
 from datastream.tools.repeat_map_chain import repeat_map_chain
 from datastream.tools.numpy_seed import numpy_seed
-from datastream.tools.split_dataframes import (
-    split_dataframes, group_split_dataframes
-)
+from datastream.tools.split_dataframes import split_dataframes

--- a/datastream/tools/split_dataframes.py
+++ b/datastream/tools/split_dataframes.py
@@ -144,12 +144,8 @@ def unassigned(keys, split):
 
 def n_target_split(keys, proportion):
     float_target_split = len(keys) * proportion
-
     probability = float_target_split - int(float_target_split)
-    if probability >= 1e-6 and np.random.rand() <= probability:
-        return int(float_target_split) + 1
-    else:
-        return int(float_target_split)
+    return int(float_target_split) + int(np.random.rand() <= probability)
 
 
 def selected(k, unassigned):

--- a/datastream/tools/split_dataframes.py
+++ b/datastream/tools/split_dataframes.py
@@ -89,7 +89,7 @@ def split_proportion(
         else:
             split = previous_split
             split[split_name] += selected(
-                n_target_split_ - n_previous_split,
+                min(n_target_split_ - n_previous_split, len(unassigned_)),
                 unassigned_,
             )
             return split

--- a/datastream/tools/stratified_split.py
+++ b/datastream/tools/stratified_split.py
@@ -9,7 +9,7 @@ def stratified_split(
     key_column: str,
     proportions: Dict[str, float],
     stratify_column: Optional[str] = None,
-    save_directory: Optional[Path] = None,
+    filepath: Optional[Path] = None,
     seed: Optional[int] = None,
     frozen: Optional[bool] = False,
 ):
@@ -33,10 +33,7 @@ def stratified_split(
             stratum,
             key_column=key_column,
             proportions=proportions,
-            filepath=(
-                save_directory / f'{hash(stratum_value)}.json'
-                if save_directory is not None else None
-            ),
+            filepath=filepath,
             seed=seed,
             frozen=frozen,
         )

--- a/datastream/tools/stratified_split.py
+++ b/datastream/tools/stratified_split.py
@@ -1,0 +1,50 @@
+import warnings
+from typing import Dict, Optional
+from pathlib import Path
+from datastream import tools
+
+
+def stratified_split(
+    dataset,
+    key_column: str,
+    proportions: Dict[str, float],
+    stratify_column: Optional[str] = None,
+    save_directory: Optional[Path] = None,
+    seed: Optional[int] = None,
+    frozen: Optional[bool] = False,
+):
+    if (
+        stratify_column is not None
+        and any(dataset.dataframe[key_column].duplicated())
+    ):
+        # mathematically impossible in the general case
+        warnings.warn(
+            'Trying to do stratified split with non-unique key column'
+            ' - cannot guarantee correct splitting of key values.'
+        )
+    strata = {
+        stratum_value: dataset.subset(
+            lambda df: df[stratify_column] == stratum_value
+        )
+        for stratum_value in dataset.dataframe[stratify_column].unique()
+    }
+    split_strata = [
+        tools.unstratified_split(
+            stratum,
+            key_column=key_column,
+            proportions=proportions,
+            filepath=(
+                save_directory / f'{hash(stratum_value)}.json'
+                if save_directory is not None else None
+            ),
+            seed=seed,
+            frozen=frozen,
+        )
+        for stratum_value, stratum in strata.items()
+    ]
+    return {
+        split_name: type(dataset).concat(
+            [split_stratum[split_name] for split_stratum in split_strata]
+        )
+        for split_name in proportions.keys()
+    }

--- a/datastream/tools/unstratified_split.py
+++ b/datastream/tools/unstratified_split.py
@@ -1,0 +1,27 @@
+from typing import Dict, Optional
+from pathlib import Path
+from datastream import tools
+
+
+def unstratified_split(
+    dataset,
+    key_column: str,
+    proportions: Dict[str, float],
+    filepath: Optional[Path] = None,
+    seed: Optional[int] = None,
+    frozen: Optional[bool] = False,
+):
+    split_dataframes = tools.numpy_seed(seed)(tools.split_dataframes)
+    return {
+        split_name: dataset.replace(
+            dataframe=dataframe,
+            length=len(dataframe),
+        )
+        for split_name, dataframe in split_dataframes(
+            dataset.dataframe,
+            key_column,
+            proportions,
+            filepath=filepath,
+            frozen=frozen,
+        ).items()
+    }


### PR DESCRIPTION
Simplify dataset.split and split_dataframes
    
    - split_dataframes no longer accepts stratify_column argument
    - dataset.split handles group_split automatically
    - add _stratified_split and _unstratified_split methods to dataset
    - strata splits are stored in separate files
    - add some tests related to splitting and move tests from split_dataframe to dataset

BREAKING CHANGE: dataset.split now takes a save_directory argument and dataset.group_split no longer exists (use dataset.split)