### PR TITLE
fix: duplicate split keys

### DIFF
--- a/datastream/tools/split_dataframes.py
+++ b/datastream/tools/split_dataframes.py
@@ -58,7 +58,7 @@ def split_dataframes(
             )
 
         last_split_name, _ = split_proportions[-1]
-        split[last_split_name] += unassigned(dataframe[key_column], split)
+        split[last_split_name] += unassigned(key_dataframe[key_column], split)
 
         if filepath is not None:
             filepath.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
`key_dataframe` contains the unique key column values and that's what we should be using when creating the splits. It was using `dataframe` before when putting the remaining key values in the last split which is why we would see duplicate keys only in the last split (e.g. in compare but not in train).

For reference
```key_dataframe = pd.DataFrame({key_column: np.sort(dataframe[key_column].unique())})```

Note: this doesn't actually change the way splitting works and everything was working fine before, we just had duplicate entries in our json files.